### PR TITLE
Ajout possibilité de s'authentifier et reset les tables.

### DIFF
--- a/account.ts
+++ b/account.ts
@@ -1,0 +1,19 @@
+export let admin = new Map<string, string>();
+export let employe = new Map<string, string>();
+
+admin.set("Teemo", "Bantam");
+admin.set("admin", "admin");
+
+employe.set("Sergio", "Delafenetre");
+employe.set("Fenetre", "Delasergio");
+
+
+export function checkRights(id:string, password:string):number {
+    if (id in admin.keys() && admin.get(id)===password) {
+        return 2;
+    }
+    if (id in employe.keys() && employe.get(id)===password) {
+        return 1;
+    }
+    return 0;
+}

--- a/routes/reset.ts
+++ b/routes/reset.ts
@@ -1,0 +1,23 @@
+import {app, client} from "../server";
+import {readFileSync} from 'fs'
+    ;
+import {checkRights} from "../account";
+export function reset_tables(){
+    app.post("/users", async (req : any, res : any): Promise<void> => {
+        const postData = req.body;
+        if (postData.id===undefined || postData.password===undefined) {
+            throw new Error("Pas authentifié. Un compte admin est nécessaire.");
+        }
+        if (checkRights(postData.id, postData.password)!==2) {
+            throw new Error("Pas les droits/mauvais nom d'utilisateur ou mot de passe.");
+        }
+        try {
+            await client.query(readFileSync("../sql/createTables.sql",'utf8'));
+            await client.query(readFileSync("../sql/populateTables.sql",'utf8'));
+            res.status(200).json({success: 'Tables réinitialisées.'});
+        } catch (err) {
+            console.error("Error :", err);
+            res.status(500).json({error: 'An error occurred (reset)'});
+        }
+    });
+}

--- a/server.ts
+++ b/server.ts
@@ -6,18 +6,22 @@ require("dotenv").config();
 
 export const app = express();
 
+//Comptes
+import {admin, employe, checkRights} from "./account";
 
 //Routes
 import {route_users} from "./routes/users";
 import {route_intervention} from "./routes/intervention";
 import {route_git} from "./routes/git";
 import {route_data} from "./routes/data";
+import {reset_tables} from "./routes/reset";
 
 
 route_users();
 route_intervention();
 route_git();
 route_data();
+reset_tables();
 
 const port: String | 3001 = process.env.PORT || 3001;
 const corsOptions: { origin: string[] } = {


### PR DESCRIPTION
Le front devra fournir les champs `id` et `password` lors de la requête POST pour s'authentifier et effectuer des requêtes avancées selon le type de compte : `admin` ou `employe`.

La route `/reset' sert à réinitialiser les tables depuis le front (nécessite un compte admin).

Les comptes (ids et mot de passes) sont dans `account.ts`.