### PR TITLE
[Important] Bug fix, ajout routes insertion.

### DIFF
--- a/account.ts
+++ b/account.ts
@@ -8,12 +8,20 @@ employe.set("Sergio", "Delafenetre");
 employe.set("Fenetre", "Delasergio");
 
 
-export function checkRights(id:string, password:string):number {
-    if (id in admin.keys() && admin.get(id)===password) {
+function getRights(id:string, password:string):number {
+    if (admin.has(id) && admin.get(id)===password) {
         return 2;
     }
-    if (id in employe.keys() && employe.get(id)===password) {
+    if (employe.has(id) && employe.get(id)===password) {
         return 1;
     }
     return 0;
+}
+
+export function checkRights(body:any):number {
+    if (body.id===undefined || body.password===undefined) {
+        console.log("Pas authentifié. Un compte admin est nécessaire.");
+        return 0;
+    }
+    return getRights(body.id, body.password);
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.16",
+    "@types/cors": "^2.8.17",
     "@types/pg": "^8.10.9"
   }
 }

--- a/routes/insertion.ts
+++ b/routes/insertion.ts
@@ -1,0 +1,87 @@
+import {app, client} from "../server";
+import {checkRights} from "../account";
+
+export function create_insert_routes(table_name: string, fields: string[]){
+    app.post(`/insertion/${table_name}`, async (req, res) => {
+        const postData = req.body;
+
+        if (checkRights(postData)<2) {
+            console.log("Pas les droits/mauvais nom d'utilisateur ou mot de passe.");
+            return res.status(500).json({error: "Pas les droits/mauvais nom d'utilisateur ou mot de passe."});
+        }
+
+        if (fields.some((x) => !(x in postData))) { //Si des attributs ne sont pas dans postData
+            const types = (await client.query(`SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '${table_name}';`)).rows.slice(1).map((row)=>{const { column_name, data_type } = row; return `${column_name}: ${data_type}`}).join(", ");
+            return res.status(500).json({error: 'Champ(s) invalides. Attendu(s) : '+types});
+        }
+
+        try {
+            const data = fields.map((field)=>(typeof postData[field] === 'string' ? `'${ postData[field]}'` : postData[field])).join(", ");
+            await client.query(`INSERT INTO ${table_name}(${fields.join(', ')}) VALUES (${data});`);
+            res.status(200).json({success: `Données insérées dans la table ${table_name}: ${data}`});
+        } catch (err) {
+            console.error("Error :", err);
+            const types = (await client.query(`SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '${table_name}';`)).rows.slice(1).map((row)=>{const { column_name, data_type } = row; return `${column_name}: ${data_type}`}).join(", ");
+            res.status(500).json({error: `Une erreur est survenue lors de l'insertion dans ${table_name}: ${types}`, err});
+        }
+    })
+}
+
+export function create_insert_routes2(table_names:string[], fields:string[][]){
+    app.post(`/insertion/${table_names[0]}`, async (req, res) => {
+        const postData = req.body;
+
+        if (checkRights(postData)<2) {
+            console.log("Pas les droits/mauvais nom d'utilisateur ou mot de passe.");
+            return res.status(500).json({error: "Pas les droits/mauvais nom d'utilisateur ou mot de passe."});
+        }
+
+        if (fields[0].slice(2).some((x) => !(x in postData)) || fields[1].some((x) => !(x in postData)) || fields[2].some((x) => !(x in postData))) {
+            const types0 = (await client.query(`SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '${table_names[0]}';`)).rows.slice(2).map((row)=>{const { column_name, data_type } = row; return `${column_name}: ${data_type}`}).join(", ");
+            const types1 = (await client.query(`SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '${table_names[1]}';`)).rows.slice(1).map((row)=>{const { column_name, data_type } = row; return `${column_name}: ${data_type}`}).join(", ");
+            const types2 = (await client.query(`SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '${table_names[2]}';`)).rows.slice(1).map((row)=>{const { column_name, data_type } = row; return `${column_name}: ${data_type}`}).join(", ");
+            return res.status(500).json({error: `Champ(s) invalides. Attendu(s) : ${types0}, ${types1}, ${types2}`});
+        }
+
+        const keys = fields[0].slice(0, 2);
+        try {
+            const key1:number = (await client.query(`INSERT INTO ${table_names[1]}(${fields[1].join(', ')}) VALUES (${fields[1].map((field)=>(typeof postData[field] === 'string' ? `'${postData[field]}'` : postData[field])).join(", ") }) RETURNING ${keys[0]};`)).rows[0][keys[0]];
+            const key2:number = (await client.query(`INSERT INTO ${table_names[2]}(${fields[2].join(', ')}) VALUES (${fields[2].map((field)=>(typeof postData[field] === 'string' ? `'${postData[field]}'` : postData[field])).join(", ") }) RETURNING ${keys[1]};`)).rows[0][keys[1]];
+
+            let values="";
+            if (fields[0].length>2)
+                values = ` , ${fields[0].slice(2).map((field)=>(typeof postData[field] === 'string' ? `'${postData[field]}'` : postData[field])).join(", ") }`;
+
+            await client.query(`INSERT INTO ${table_names[0]}(${fields[0].join(', ')}) VALUES (${key1}, ${key2}${values});`);
+            res.status(200).json({success: `Données insérées dans les tables ${table_names.join(", ")}.`});
+        } catch (err) {
+            console.error("Error :", err);
+            res.status(500).json({error: `Une erreur est survenue lors de l'insertion dans ${table_names.join(", ")}`, err});
+        }
+    })
+}
+
+export let tables_champs = new Map<string, string[]>();
+tables_champs.set("constructeurs", ["nom_constructeur"]);
+tables_champs.set("clients", ["nom_client", "prenom_client", "adresse_client", "mail_client", "telephone_client"]);
+tables_champs.set("pieces", ["nom_piece"]);
+tables_champs.set("personnels", ["nom_employe", "prenom_employe", "telephone_employe", "poste"]);
+tables_champs.set("fabricants", ["nom_fabricant", "adresse_fabricant"]);
+tables_champs.set("actions", ["intitule", "cout_action", "duree"]);
+tables_champs.set("garages", ["nom_garage", "adresse_garage"]);
+tables_champs.set("modeles", ["nom_modele", "type_motorisation", "id_constructeur"]);
+tables_champs.set("vehicules", ["immatriculation", "date_de_mise_en_circulation", "type_vehicule", "id_client", "id_modele"]);
+tables_champs.set("interventions", ["date_prise_en_charge", "date_retour_prevue", "kilometrage", "type_intervention", "etat_intervention", "origine_intervention", "id_vehicule", "id_garage"]);
+tables_champs.set("factures", ["montant", "id_intervention", "id_client", "date_facture"]);
+
+export let tables_champs2 = new Map<string[], string[][]>();
+// @ts-ignore
+tables_champs2.set(["contenir", "pieces", "modeles"], [["id_piece", "id_modele"], tables_champs.get("pieces"), tables_champs.get("modeles")]);
+// @ts-ignore
+tables_champs2.set(["fabriquer", "pieces", "fabricants"], [["id_piece", "id_fabricant", "cout_piece"], tables_champs.get("pieces"), tables_champs.get("fabricants")]);
+// @ts-ignore
+tables_champs2.set(["realiser", "actions", "interventions"], [["id_action", "id_intervention"], tables_champs.get("actions"), tables_champs.get("interventions")]);
+// @ts-ignore
+tables_champs2.set(["remplacer", "pieces", "interventions"], [["id_piece", "id_intervention"], tables_champs.get("pieces"), tables_champs.get("interventions")]);
+// @ts-ignore
+tables_champs2.set(["travailler", "personnels", "interventions"], [["id_employe", "id_intervention"], tables_champs.get("personnels"), tables_champs.get("interventions")]);

--- a/routes/reset.ts
+++ b/routes/reset.ts
@@ -1,19 +1,18 @@
 import {app, client} from "../server";
-import {readFileSync} from 'fs'
-    ;
+import {readFileSync} from 'fs';
 import {checkRights} from "../account";
+
 export function reset_tables(){
-    app.post("/users", async (req : any, res : any): Promise<void> => {
+    app.post("/reset", async (req : any, res : any): Promise<void> => {
         const postData = req.body;
-        if (postData.id===undefined || postData.password===undefined) {
-            throw new Error("Pas authentifié. Un compte admin est nécessaire.");
-        }
-        if (checkRights(postData.id, postData.password)!==2) {
-            throw new Error("Pas les droits/mauvais nom d'utilisateur ou mot de passe.");
+
+        if (checkRights(postData)!==2) {
+            console.log("Pas les droits/mauvais nom d'utilisateur ou mot de passe.");
+            return res.status(500).json({error: "Pas les droits/mauvais nom d'utilisateur ou mot de passe."});
         }
         try {
-            await client.query(readFileSync("../sql/createTables.sql",'utf8'));
-            await client.query(readFileSync("../sql/populateTables.sql",'utf8'));
+            await client.query(readFileSync("./sql/createTables.sql",'utf8'));
+            await client.query(readFileSync("./sql/populateTables.sql",'utf8'));
             res.status(200).json({success: 'Tables réinitialisées.'});
         } catch (err) {
             console.error("Error :", err);

--- a/server.ts
+++ b/server.ts
@@ -6,34 +6,37 @@ require("dotenv").config();
 
 export const app = express();
 
-//Comptes
-import {admin, employe, checkRights} from "./account";
+const corsOptions: { origin: string[] } = {
+    origin: [
+        "https://larwive.github.io",
+        "https://api.github.com",
+        "http://localhost:3000",
+        "http://10.188.86.239:3000",
+        "*"
+    ], // Reminder : enlever localhost:*
+};
 
+app.use(cors(corsOptions)); // Enable CORS for all routes
+app.use(express.json());
 //Routes
 import {route_users} from "./routes/users";
 import {route_intervention} from "./routes/intervention";
 import {route_git} from "./routes/git";
 import {route_data} from "./routes/data";
 import {reset_tables} from "./routes/reset";
-
+import {create_insert_routes, create_insert_routes2, tables_champs, tables_champs2} from "./routes/insertion";
 
 route_users();
 route_intervention();
 route_git();
 route_data();
 reset_tables();
+Array.from(tables_champs.entries()).map(([table_name, fields])=>{create_insert_routes(table_name, fields)});
+Array.from(tables_champs2.entries()).map(([table_names, fieldss])=>{create_insert_routes2(table_names, fieldss)});
 
 const port: String | 3001 = process.env.PORT || 3001;
-const corsOptions: { origin: string[] } = {
-    origin: [
-        "https://larwive.github.io",
-        "https://api.github.com",
-        "http://localhost:3000",
-    ], // Reminder : enlever localhost:*
-};
 
-app.use(cors(corsOptions)); // Enable CORS for all routes
-app.use(express.json());
+
 
 // Database connection
 export const client = new Client({

--- a/server.ts
+++ b/server.ts
@@ -10,9 +10,7 @@ const corsOptions: { origin: string[] } = {
     origin: [
         "https://larwive.github.io",
         "https://api.github.com",
-        "http://localhost:3000",
-        "http://10.188.86.239:3000",
-        "*"
+        "http://localhost:3000"
     ], // Reminder : enlever localhost:*
 };
 


### PR DESCRIPTION
Fix des bugs du serveur, ajout routes pour insérer des données.

L'insertion nécessite les droits admin. Les routes sont dans la forme `insertion/${nom_de_table}`.

Pour insérer dans un table, il suffit de fournir les attributs correspondants lors de la requête POST. Les clés primaires ne sont pas pris en compte car incrémentés automatiquement.

Pour les tables issues des cardinalités ..n-..n, l'insertion se fera dans les 3 tables correspondantes si les attributs des 3 tables sont présents dans la requête. Les clés secondaires (si présentes) sont requis pour les tables liées.

En cas de mauvaise utilisation, la liste des attributs requis est renvoyée dans la console.